### PR TITLE
Move section break for tickets after the title

### DIFF
--- a/themes/gopherconsg-2017/layouts/partials/index/tickets.html
+++ b/themes/gopherconsg-2017/layouts/partials/index/tickets.html
@@ -6,10 +6,10 @@
                 {{ with .Site.Data.index.tickets.headline }}
                 <h2 class="section-heading">{{ . }}</h2>
                 {{ end }}
+                <hr class="primary">
                 <tito-widget event="gopherconsg/2019" ssl-check-disabled></tito-widget>
                 <link rel="stylesheet" type="text/css" href='https://css.tito.io/v1.1' />
                 {{ with .Site.Data.index.tickets.policy }}
-                <hr class="primary">
                 {{ . | markdownify }}
                 {{ end }}
             </div>


### PR DESCRIPTION
## Before
<img width="822" alt="before" src="https://user-images.githubusercontent.com/15604207/52612755-1a3b3180-2ec6-11e9-9b26-7db44bbf82a3.png">
Currently, the section break for tickets is after the tito dialog, which is inconsistent with the rest of the sections

## After
<img width="941" alt="after" src="https://user-images.githubusercontent.com/15604207/52612761-23c49980-2ec6-11e9-8b89-294bb4f757f2.png">
This PR moves the section break to be just after "tickets" for consistency.