### PR TITLE
Enable SSL check for tito

### DIFF
--- a/themes/gopherconsg-2017/layouts/partials/index/tickets.html
+++ b/themes/gopherconsg-2017/layouts/partials/index/tickets.html
@@ -7,7 +7,7 @@
                 <h2 class="section-heading">{{ . }}</h2>
                 {{ end }}
                 <hr class="primary">
-                <tito-widget event="gopherconsg/2019" ssl-check-disabled></tito-widget>
+                <tito-widget event="gopherconsg/2019"></tito-widget>
                 <link rel="stylesheet" type="text/css" href='https://css.tito.io/v1.1' />
                 {{ with .Site.Data.index.tickets.policy }}
                 {{ . | markdownify }}


### PR DESCRIPTION
https://2019.gophercon.sg/ is protected by SSL from LetsEncrypt and [Tito recommends turning on SSL](https://ti.to/docs/widget#ssl)

This PR enables SSL check on the Tito widget.